### PR TITLE
Implement the `Unwrap` interface for the `SkipCacheError` type

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -70,6 +70,10 @@ func (s *SkipCacheError) Error() string {
 	return s.err.Error()
 }
 
+func (s *SkipCacheError) Unwrap() error {
+	return s.err
+}
+
 func NewSkipCacheError(err error) *SkipCacheError {
 	return &SkipCacheError{err: err}
 }


### PR DESCRIPTION
This PR implements the `Unwrap` interface for the `SkipCacheError` type. This allows the use of `errors.Is` to test wrapped errors.

Example:
https://go.dev/play/p/HI9DIbkQKrw