### PR TITLE
Add tracing method to wait

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
-module github.com/uphold-forks/dataloader/v7
+module github.com/kamefrede/dataloader/v7
 
 go 1.18
+
+replace github.com/graph-gophers/dataloader/v7 => ./
 
 require (
 	github.com/graph-gophers/dataloader/v7 v7.1.0

--- a/trace.go
+++ b/trace.go
@@ -7,6 +7,7 @@ import (
 type TraceLoadFinishFunc[V any] func(Thunk[V])
 type TraceLoadManyFinishFunc[V any] func(ThunkMany[V])
 type TraceBatchFinishFunc[V any] func([]*Result[V])
+type TraceWaitFinishFunc[V any] func(keys []V)
 
 // Tracer is an interface that may be used to implement tracing.
 type Tracer[K comparable, V any] interface {
@@ -16,6 +17,8 @@ type Tracer[K comparable, V any] interface {
 	TraceLoadMany(ctx context.Context, keys []K) (context.Context, TraceLoadManyFinishFunc[V])
 	// TraceBatch will trace data loader batches.
 	TraceBatch(ctx context.Context, keys []K) (context.Context, TraceBatchFinishFunc[V])
+	// TraceWait will trace waits between load and batches.
+	TraceWait(ctx context.Context) (context.Context, TraceWaitFinishFunc[K])
 }
 
 // NoopTracer is the default (noop) tracer
@@ -34,4 +37,9 @@ func (NoopTracer[K, V]) TraceLoadMany(ctx context.Context, keys []K) (context.Co
 // TraceBatch is a noop function
 func (NoopTracer[K, V]) TraceBatch(ctx context.Context, keys []K) (context.Context, TraceBatchFinishFunc[V]) {
 	return ctx, func(result []*Result[V]) {}
+}
+
+// TraceWait is a noop function
+func (NoopTracer[K, V]) TraceWait(ctx context.Context) (context.Context, TraceWaitFinishFunc[K]) {
+	return ctx, func([]K) {}
 }

--- a/trace/opentracing/trace.go
+++ b/trace/opentracing/trace.go
@@ -44,3 +44,14 @@ func (Tracer[K, V]) TraceBatch(ctx context.Context, keys []K) (context.Context, 
 		span.Finish()
 	}
 }
+
+// TraceWait will trace the wait time between load and batch calls with Open Tracing.
+func (Tracer[K, V]) TraceWait(ctx context.Context) (context.Context, dataloader.TraceWaitFinishFunc[K]) {
+	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: wait")
+
+	return spanCtx, func(keys []K) {
+		span.SetTag("dataloader.keys", fmt.Sprintf("%v", keys))
+
+		span.Finish()
+	}
+}

--- a/trace/otel/trace.go
+++ b/trace/otel/trace.go
@@ -59,3 +59,14 @@ func (t Tracer[K, V]) TraceBatch(ctx context.Context, keys []K) (context.Context
 		span.End()
 	}
 }
+
+// TraceWait will trace the wait time between load and batch calls with Otel.
+func (t Tracer[K, V]) TraceWait(ctx context.Context) (context.Context, dataloader.TraceWaitFinishFunc[K]) {
+	spanCtx, span := t.Tracer().Start(ctx, "Dataloader: wait")
+
+	return spanCtx, func(keys []K) {
+		span.SetAttributes(attribute.String("dataloader.keys", fmt.Sprintf("%v", keys)))
+
+		span.End()
+	}
+}


### PR DESCRIPTION
# Description

This PR adds a new tracing method `TraceWait`, to fill in the missing gap between `Load` and `Batch`
